### PR TITLE
Make PluralRules.Generator.csproj use stable Microsoft.CodeAnalysis.CSharp

### DIFF
--- a/PluralRules.Generator/PluralRules.Generator.csproj
+++ b/PluralRules.Generator/PluralRules.Generator.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0-3.final" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all"/>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all"/>
     </ItemGroup>
 


### PR DESCRIPTION
This fixes the compilation warning in Robust about non-matching package selection.