### PR TITLE
Fixed floating point tests failing on German .NET

### DIFF
--- a/Linguini.Bundle.Test/Unit/TestRules.cs
+++ b/Linguini.Bundle.Test/Unit/TestRules.cs
@@ -60,7 +60,7 @@ namespace Linguini.Bundle.Test.Unit
                 var midDouble = (end.Value - start.Value) / 2 + start;
                 FluentNumber mid = isDecimal
                     ? midDouble
-                    : Convert.ToInt32(Math.Floor(midDouble));
+                    : Convert.ToInt32(Math.Floor(midDouble), CultureInfo.InvariantCulture);
 
                 var actualStart = GetPluralCategory(info, type, start);
                 Assert.AreEqual(expected, actualStart, $"Failed on start of range: {start}");

--- a/Linguini.Shared/Types/Bundle/FluentNumber.cs
+++ b/Linguini.Shared/Types/Bundle/FluentNumber.cs
@@ -45,7 +45,7 @@ namespace Linguini.Shared.Types.Bundle
 
         public static FluentNumber FromString(ReadOnlySpan<char> input)
         {
-            var parsed = Double.Parse(input);
+            var parsed = Double.Parse(input, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
             var options = new FluentNumberOptions();
             if (input.IndexOf('.') != -1)
             {

--- a/PluralRules.Test/Types/PluralOperandsTests.cs
+++ b/PluralRules.Test/Types/PluralOperandsTests.cs
@@ -152,7 +152,7 @@ namespace PluralRule.Test.Types
         {
             if (input >= float.MinValue && input <= float.MaxValue)
             {
-                float floatInput = Convert.ToSingle(input);
+                float floatInput = Convert.ToSingle(input, CultureInfo.InvariantCulture);
                 var x = floatInput.TryPluralOperands(out var operands);
                 CheckInput(n, i, v, w, f, t, x, operands);
             }


### PR DESCRIPTION
due to `.` vs `,` as decimal separator.