### PR TITLE
Add support for netstandard2.1

### DIFF
--- a/Linguini.Bundle.Test/Linguini.Bundle.Test.csproj
+++ b/Linguini.Bundle.Test/Linguini.Bundle.Test.csproj
@@ -9,7 +9,6 @@
 
     <ItemGroup>
         <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
         <PackageReference Include="YamlDotNet" Version="11.0.1" />
     </ItemGroup>

--- a/Linguini.Bundle.Test/Linguini.Bundle.Test.csproj
+++ b/Linguini.Bundle.Test/Linguini.Bundle.Test.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
+        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+        <OutputType>Library</OutputType>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Linguini.Bundle/IsExternalInit.cs
+++ b/Linguini.Bundle/IsExternalInit.cs
@@ -1,0 +1,6 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit
+    {
+    }
+}

--- a/Linguini.Bundle/Linguini.Bundle.csproj
+++ b/Linguini.Bundle/Linguini.Bundle.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <Title>Linguini Bundle - Fluent implementation</Title>
         <Description>Linguini Bundle is the C# implementation of Project Fluent, a localization system developed by Mozilla
@@ -20,6 +19,7 @@ It provides easy to use and extend system for describing translations.</Descript
         <PackageProjectUrl>https://github.com/Ygg01/Linguini</PackageProjectUrl>
         <RepositoryType>git</RepositoryType>
         <PackageVersion>0.1.4</PackageVersion>
+        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Linguini.Bundle/Linguini.Bundle.csproj
+++ b/Linguini.Bundle/Linguini.Bundle.csproj
@@ -18,7 +18,7 @@ It provides easy to use and extend system for describing translations.</Descript
         <Win32Resource />
         <PackageProjectUrl>https://github.com/Ygg01/Linguini</PackageProjectUrl>
         <RepositoryType>git</RepositoryType>
-        <PackageVersion>0.1.4</PackageVersion>
+        <PackageVersion>0.2.0</PackageVersion>
         <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
     </PropertyGroup>
 

--- a/Linguini.Shared/Linguini.Shared.csproj
+++ b/Linguini.Shared/Linguini.Shared.csproj
@@ -10,7 +10,7 @@
         <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>
         <PackageTags>fluent, i18n, internationalization, l10n, l20n, globalization, translation</PackageTags>
         <IncludeSymbols>false</IncludeSymbols>
-        <PackageVersion>0.1.4</PackageVersion>
+        <PackageVersion>0.2.0</PackageVersion>
     </PropertyGroup>
 
 </Project>

--- a/Linguini.Shared/Util/ZeroCopyUtil.cs
+++ b/Linguini.Shared/Util/ZeroCopyUtil.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace Linguini.Shared.Util
@@ -182,6 +183,25 @@ namespace Linguini.Shared.Util
             var x = MemoryMarshal.GetReference(charSpan);
             return x == c1 || x == c2 || x == c3 || x == c4;
         }
+#if NETSTANDARD2_1_OR_GREATER
+        // Polyfill for netstandard 2.1 until dotnet backports MemoryExtension
+        public static ReadOnlyMemory<char> TrimEndPolyFill(this ReadOnlyMemory<char> memory)
+            => memory.Slice(0, FindLastWhitespace(memory.Span));
+
+        private static int FindLastWhitespace(ReadOnlySpan<char> span)
+        {
+            int end = span.Length - 1;
+            for (; end >= 0; end--)
+            {
+                if (!char.IsWhiteSpace(span[end]))
+                {
+                    break;
+                }
+            }
+
+            return end + 1;
+        }
+#endif
 
         private static bool IsInside(char c, char min, char max) => (uint) (c - min) <= (uint) (max - min);
     }

--- a/Linguini.Syntax.Tests/Linguini.Syntax.Tests.csproj
+++ b/Linguini.Syntax.Tests/Linguini.Syntax.Tests.csproj
@@ -14,7 +14,6 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions.Json" Version="4.17.0" />
         <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     </ItemGroup>
 

--- a/Linguini.Syntax.Tests/Linguini.Syntax.Tests.csproj
+++ b/Linguini.Syntax.Tests/Linguini.Syntax.Tests.csproj
@@ -1,11 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 
         <Nullable>enable</Nullable>
+
+        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+
+        <OutputType>Library</OutputType>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Linguini.Syntax/Linguini.Syntax.csproj
+++ b/Linguini.Syntax/Linguini.Syntax.csproj
@@ -12,10 +12,11 @@
         <PackageProjectUrl>https://github.com/Ygg01/Linguini</PackageProjectUrl>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+        <PackageVersion>0.2.0</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Linguini.Shared\Linguini.Shared.csproj" />
-        <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.1'" Include="System.Text.Json" Version="6.0.3"/>
+        <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.1'" Include="System.Text.Json" Version="6.0.3" />
     </ItemGroup>
 </Project>

--- a/Linguini.Syntax/Linguini.Syntax.csproj
+++ b/Linguini.Syntax/Linguini.Syntax.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Title>Linguini Syntax - Zero Copy parser used to parse Fluent syntax</Title>
@@ -12,9 +11,11 @@
         <PackageTags>fluent, i18n, internationalization, l10n, l20n, globalization, translation</PackageTags>
         <PackageProjectUrl>https://github.com/Ygg01/Linguini</PackageProjectUrl>
         <RepositoryType>git</RepositoryType>
+        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Linguini.Shared\Linguini.Shared.csproj" />
+        <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.1'" Include="System.Text.Json" Version="6.0.3"/>
     </ItemGroup>
 </Project>

--- a/Linguini.Syntax/Parser/LinguiniParser.cs
+++ b/Linguini.Syntax/Parser/LinguiniParser.cs
@@ -574,7 +574,12 @@ namespace Linguini.Syntax.Parser
                             var value = _reader.ReadSlice(start, end);
                             if (lastNonBlank == i)
                             {
+#if NET5_0_OR_GREATER
                                 value = value.TrimEnd();
+#endif
+#if NETSTANDARD2_1_OR_GREATER
+                                value = value.TrimEndPolyFill();
+#endif
                             }
 
                             patterns.Add(new TextLiteral(value));

--- a/PluralRules.Test/PluralRules.Test.csproj
+++ b/PluralRules.Test/PluralRules.Test.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
         <RootNamespace>PluralRules.Test</RootNamespace>
+        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+        <OutputType>Library</OutputType>
     </PropertyGroup>
 
     <ItemGroup>

--- a/PluralRules.Test/PluralRules.Test.csproj
+++ b/PluralRules.Test/PluralRules.Test.csproj
@@ -10,7 +10,6 @@
 
     <ItemGroup>
         <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     </ItemGroup>
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,3 +18,8 @@ version 0.1.3
 version 0.1.4
     - Fix issue with number formatting using `CultureInfo.CurrentCulture` instead of `CultureInfo.InvariantCulture`. 
      Big thanks to @Mailaender
+
+version 0.2.0
+    - Linguini supports netstandard2.1 for use in Mono (this changes no API but introduces 
+    polyfills for netstandard2.1)
+    - Fix some stale dependencies


### PR DESCRIPTION
# Motivation
@Mailaender needs Mono compatibility and for that, we need to target `netstandard2.1`.

Should not affect much, but I will bump versions to v0.2.0 to prevent possible breakage on SS14.

# API changes
Added polyfills and some classes to enable `netstandard2.1` compatibility.