### PR TITLE
Add mono as target for testing netstandard 2.1

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,3 +26,16 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build  --verbosity normal
+      
+  linux-mono:
+    name: Linux (mono)
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Clone Repository
+      uses: actions/checkout@v2
+
+    - name: Check Code
+      run: |
+        mono --version
+        msbuild -t:Build -restore


### PR DESCRIPTION
Fixes #7 

Would prevent breaking Mono. Note branch might fail due to Roslyn Analysers in `System.Text.Json`