### PR TITLE
Set the local arguments of a Scope to null instead of an empty dict

### DIFF
--- a/Linguini.Bundle/Resolver/Scope.cs
+++ b/Linguini.Bundle/Resolver/Scope.cs
@@ -138,7 +138,7 @@ namespace Linguini.Bundle.Resolver
         {
             _localArgs = resNamed != null
                 ? new Dictionary<string, IFluentType>(resNamed)
-                : new Dictionary<string, IFluentType>();
+                : null;
         }
 
         public PluralCategory GetPluralRules(RuleType type, FluentNumber number)


### PR DESCRIPTION
Resetting the arguments to an empty dictionary breaks the `var args = scope.LocalArgs ?? scope.Args;` pattern that is used two times (https://github.com/Ygg01/Linguini/blob/898b04294883b4dc8942fd075565d6cddf8e5de3/Linguini.Bundle/Resolver/WriterHelpers.cs#L184 and https://github.com/Ygg01/Linguini/blob/898b04294883b4dc8942fd075565d6cddf8e5de3/Linguini.Bundle/Resolver/ResolverHelpers.cs#L49).
An example that breaks from https://github.com/OpenRA/OpenRA/ is using a term reference and a variable reference:
```
-incompatible-replay-recorded = It was recorded with
incompatible-replay-unknown-version = { -incompatible-replay-recorded } an unknown version: { $version }.
```
The term reference (`-incompatible-replay-recorded`) sets local arguments:
https://github.com/Ygg01/Linguini/blob/898b04294883b4dc8942fd075565d6cddf8e5de3/Linguini.Bundle/Resolver/WriterHelpers.cs#L140
and later tries to reset them to `null`:
https://github.com/Ygg01/Linguini/blob/898b04294883b4dc8942fd075565d6cddf8e5de3/Linguini.Bundle/Resolver/WriterHelpers.cs#L155-L156
However, that set the local arguments to an empty dictionary, and thus `var args = scope.LocalArgs ?? scope.Args;` evaluated to an empty dictionary, so the variable reference could not be resolved properly (the value for the variable is in `scope.Args`).

Changing `SetLocalArgs` to really use `null` instead of an empty dictionary fixes my issue/testcase.