### PR TITLE
Improve parsing performance

### DIFF
--- a/Linguini.Bundle/FluentBundle.cs
+++ b/Linguini.Bundle/FluentBundle.cs
@@ -126,15 +126,21 @@ namespace Linguini.Bundle
 
                 if (entry is AstTerm or AstMessage)
                 {
-                    AddEntry(new List<FluentError>(), entry, true);
+                    AddEntryOverriding(entry);
                 }
             }
         }
 
-        private void AddEntry(List<FluentError> errors, IEntry term, bool overwrite = false)
+        private void AddEntryOverriding(IEntry term)
         {
             var id = (term.GetId(), term.ToKind());
-            if (_entries.ContainsKey(id) && !overwrite)
+            _entries[id] = term;
+        }
+
+        private void AddEntry(List<FluentError> errors, IEntry term)
+        {
+            var id = (term.GetId(), term.ToKind());
+            if (_entries.ContainsKey(id))
             {
                 errors.Add(new OverrideFluentError(id.Item1, id.Item2));
             }

--- a/Linguini.Shared/Util/ZeroCopyUtil.cs
+++ b/Linguini.Shared/Util/ZeroCopyUtil.cs
@@ -9,123 +9,51 @@ namespace Linguini.Shared.Util
     /// </summary>
     public static class ZeroCopyUtil
     {
-        private const int CharLength = 1;
-        private static readonly ReadOnlyMemory<char> Eof = ReadOnlyMemory<char>.Empty;
-
-        public static ReadOnlySpan<char> PeakCharAt(this ReadOnlyMemory<char> memory, int pos)
+        public static bool TryReadChar(this ReadOnlyMemory<char> memory, int pos, out char c)
         {
-            memory.TryReadCharSpan(pos, out var span);
-            return span;
-        }
-
-        public static bool TryReadCharSpan(this ReadOnlyMemory<char> memory, int pos, out ReadOnlySpan<char> span)
-        {
-            span = Eof.Span;
-            if (pos + CharLength > memory.Length)
+            if (pos >= memory.Length)
             {
+                c = default;
                 return false;
             }
 
-            span = memory.Slice(pos, CharLength).Span;
+            c = memory.Span[pos];
             return true;
         }
 
-        public static bool EqualsSpans(this char chr, ReadOnlySpan<char> chrSpan)
+        public static bool IsAsciiAlphabetic(this char c)
         {
-            if (chrSpan.Length > CharLength)
-            {
-                return false;
-            }
-
-            return chrSpan.Length != 0 && IsEqual(chrSpan, chr);
-        }
-
-        public static bool EqualsSpans(this char? lhs, ReadOnlySpan<char> chrSpan)
-        {
-            if (lhs == null)
-            {
-                return chrSpan == Eof.Span;
-            }
-
-            return EqualsSpans((char) lhs, chrSpan);
-        }
-
-        public static bool IsEqual(this ReadOnlySpan<char> charSpan, char c1)
-        {
-            if (charSpan.Length != CharLength)
-            {
-                return false;
-            }
-
-            return MemoryMarshal.GetReference(charSpan) == c1;
-        }
-
-        public static bool IsAsciiAlphabetic(this ReadOnlySpan<char> charSpan)
-        {
-            if (charSpan.Length != CharLength)
-            {
-                return false;
-            }
-
-            var c = MemoryMarshal.GetReference(charSpan);
             return IsInside(c, 'a', 'z')
                    || IsInside(c, 'A', 'Z');
         }
 
-        public static bool IsAsciiHexdigit(this ReadOnlySpan<char> charSpan)
+        public static bool IsAsciiHexdigit(this char c)
         {
-            if (charSpan.Length != CharLength)
-            {
-                return false;
-            }
-
-            var c = MemoryMarshal.GetReference(charSpan);
             return IsInside(c, '0', '9')
                    || IsInside(c, 'a', 'f')
                    || IsInside(c, 'A', 'F');
         }
 
-        public static bool IsAsciiUppercase(this ReadOnlySpan<char> charSpan)
+        public static bool IsAsciiUppercase(this char c)
         {
-            if (charSpan.Length != CharLength)
-            {
-                return false;
-            }
-
-            var c = MemoryMarshal.GetReference(charSpan);
             return IsInside(c, 'A', 'Z');
         }
 
-        public static bool IsAsciiDigit(this ReadOnlySpan<char> charSpan)
+        public static bool IsAsciiDigit(this char c)
         {
-            if (charSpan.Length != CharLength)
-            {
-                return false;
-            }
-
-            var c = MemoryMarshal.GetReference(charSpan);
             return IsInside(c, '0', '9');
         }
 
-        
-
-        public static bool IsNumberStart(this ReadOnlySpan<char> charSpan)
+        public static bool IsNumberStart(this char c)
         {
-            if (charSpan.Length != CharLength)
-            {
-                return false;
-            }
-
-            var c = MemoryMarshal.GetReference(charSpan);
             return IsInside(c, '0', '9') || c == '-';
         }
 
-        public static bool IsCallee(this ReadOnlyMemory<char> charSpan)
+        public static bool IsCallee(this ReadOnlySpan<char> charSpan)
         {
             bool isCallee = true;
-            for (int i = 0; i < charSpan.Length - 1; i++)
+            foreach (var c in charSpan)
             {
-                var c = charSpan.Slice(i, 1).Span;
                 if (!(c.IsAsciiUppercase() || c.IsAsciiDigit() || c.IsOneOf('_', '-')))
                 {
                     isCallee = false;
@@ -136,53 +64,29 @@ namespace Linguini.Shared.Util
             return isCallee;
         }
 
-
-        public static bool IsIdentifier(this ReadOnlySpan<char> charSpan)
+        public static bool IsIdentifier(this char c)
         {
-            if (charSpan.Length != CharLength)
-            {
-                return false;
-            }
-
-            var c = MemoryMarshal.GetReference(charSpan);
             return IsInside(c, 'a', 'z')
                    || IsInside(c, 'A', 'Z')
                    || IsInside(c, '0', '9')
                    || c == '-' || c == '_';
         }
 
-        public static bool IsOneOf(this ReadOnlySpan<char> charSpan, char c1, char c2)
+        public static bool IsOneOf(this char c, char c1, char c2)
         {
-            if (charSpan.Length != CharLength)
-            {
-                return false;
-            }
-
-            var x = MemoryMarshal.GetReference(charSpan);
-            return x == c1 || x == c2;
+            return c == c1 || c == c2;
         }
 
-        public static bool IsOneOf(this ReadOnlySpan<char> charSpan, char c1, char c2, char c3)
+        public static bool IsOneOf(this char c, char c1, char c2, char c3)
         {
-            if (charSpan.Length != CharLength)
-            {
-                return false;
-            }
-
-            var x = MemoryMarshal.GetReference(charSpan);
-            return x == c1 || x == c2 || x == c3;
+            return c == c1 || c == c2 || c == c3;
         }
 
-        public static bool IsOneOf(this ReadOnlySpan<char> charSpan, char c1, char c2, char c3, char c4)
+        public static bool IsOneOf(this char c, char c1, char c2, char c3, char c4)
         {
-            if (charSpan.Length != CharLength)
-            {
-                return false;
-            }
-
-            var x = MemoryMarshal.GetReference(charSpan);
-            return x == c1 || x == c2 || x == c3 || x == c4;
+            return c == c1 || c == c2 || c == c3 || c == c4;
         }
+
 #if !NET5_0_OR_GREATER 
         // Polyfill for netstandard 2.1 until dotnet backports MemoryExtension
         public static ReadOnlyMemory<char> TrimEndPolyFill(this ReadOnlyMemory<char> memory)

--- a/Linguini.Syntax.Tests/IO/NonValidCharInputTest.cs
+++ b/Linguini.Syntax.Tests/IO/NonValidCharInputTest.cs
@@ -14,20 +14,10 @@ namespace Linguini.Syntax.Tests.IO
         [TestCase("단편")]
         [TestCase("かんじ")]
         [TestCase("Северный поток")]
-        public void OperationOnNonCharSpanReturnFalse(string input)
+        public void OperationOnNonCalleeReturnFalse(string input)
         {
             var span = input.AsSpan();
-            Assert.False('c'.EqualsSpans(span));
-            Assert.False(span.IsEqual('c'));
-            Assert.False(span.IsAsciiAlphabetic());
-            Assert.False(span.IsAsciiDigit());
-            Assert.False(span.IsAsciiHexdigit());
-            Assert.False(span.IsAsciiUppercase());
-            Assert.False(span.IsOneOf('c', 's'));
-            Assert.False(span.IsOneOf('c', 's', 'l'));
-            Assert.False(span.IsOneOf('c', 's', 'a', 'l'));
-            Assert.False(span.IsNumberStart());
-            Assert.False(input.AsMemory().IsCallee());
+            Assert.False(span.IsCallee());
         }
     }
 }

--- a/Linguini.Syntax/Parser/Error/ParseError.cs
+++ b/Linguini.Syntax/Parser/Error/ParseError.cs
@@ -22,7 +22,7 @@ namespace Linguini.Syntax.Parser.Error
             Row = row;
         }
 
-        public static ParseError ExpectedToken(char expected, ReadOnlySpan<char> actual, int pos, int row)
+        public static ParseError ExpectedToken(char expected, char? actual, int pos, int row)
         {
             var sb = new StringBuilder()
                 .AppendFormat("Expected a token starting with  \"{0}\" found \"{1}\" instead", expected,
@@ -36,7 +36,7 @@ namespace Linguini.Syntax.Parser.Error
             );
         }
 
-        public static ParseError ExpectedToken(char exp1, char exp2, ReadOnlySpan<char> actual, int pos, int row)
+        public static ParseError ExpectedToken(char exp1, char exp2, char? actual, int pos, int row)
         {
             var sb = new StringBuilder()
                 .AppendFormat("Expected  \"{0}\" or \"{1}\" found \"{2}\" instead",


### PR DESCRIPTION
- In LinguiniParser, ZeroCopyReader, ZeroCopyUtil: change helpers from dealing in ReadOnlyMemory<char> to char. In inner loops this removes a lot of redundant checks for a span of length 1 and inlines more readily.
- In ZeroCopyReader add helpers for SeekEol, IndexOfAnyChar. These use existing helper methods of Span that are SIMD accelerated to search for indexes quickly. These provide significant speedups compared to incrementing the index in a loop.
- In FluentBundle.AddResourceOverriding, provide a specialized 'override' method to avoid two dictionary lookups and allocating an empty list.

----

This makes parsing performance 1.5x faster. On my machine, the following test project runs in 2.9 seconds, compared to 4.5 seconds previously.

<details>

<summary>Test Project</summary>

```c#
using System;
using System.Diagnostics;
using System.Globalization;
using System.IO;
using System.Linq;
using Linguini.Bundle.Builder;
using Linguini.Syntax.Parser;

namespace ConsoleApp
{
    internal class Program
    {
        static void Main()
        {
            var sw = new Stopwatch();
            for (var i = 0; i < 10000; i++)
            {
                Setup(out var culture, out var streams);

                sw.Start();
                var bundle = LinguiniBuilder.Builder()
                    .CultureInfo(culture)
                    .SkipResources()
                    .SetUseIsolating(false)
                    .UseConcurrent()
                    .UncheckedBuild();

                foreach (var stream in streams)
                {
                    using var reader = new StreamReader(stream);
                    var parser = new LinguiniParser(reader);
                    var resource = parser.Parse();

                    bundle.AddResourceOverriding(resource);
                }
                sw.Stop();
            }

            sw.Stop();

            Console.WriteLine($"Done in {sw.Elapsed.TotalSeconds:0.00s}");
        }

        static void Setup(out CultureInfo culture, out MemoryStream[] streams)
        {
            culture = new CultureInfo("en");
            var paths = new[]
            {
                @"your-test-files-here.ftl",
            };
            streams = paths.Select(p => new MemoryStream(File.ReadAllBytes(p))).ToArray();
        }
    }
}
```

I used the following test files, but feel free to try with whatever you have to hand.
- https://github.com/OpenRA/OpenRA/blob/06df75ffee07c074f8ded8854cc9892db2d73cd2/mods/common/languages/en.ftl
- https://github.com/OpenRA/OpenRA/blob/06df75ffee07c074f8ded8854cc9892db2d73cd2/mods/common/languages/rules/en.ftl
- https://github.com/OpenRA/OpenRA/blob/06df75ffee07c074f8ded8854cc9892db2d73cd2/mods/ra/languages/rules/en.ftl
</details>