### PR TITLE
Newlines fix

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -1,0 +1,19 @@
+﻿name: Qodana
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  qodana:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: 'Qodana Scan'
+        uses: JetBrains/qodana-action@v2023.2
+        env:
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/Linguini.Syntax.Tests/Parser/LinguiniParserTest.cs
+++ b/Linguini.Syntax.Tests/Parser/LinguiniParserTest.cs
@@ -175,7 +175,7 @@ namespace Linguini.Syntax.Tests.Parser
         public void TestNumExpressions(string input, string identifier, string value)
         {
             var res = new LinguiniParser(input).Parse();
-
+            
             Assert.AreEqual(0, res.Errors.Count);
             Assert.AreEqual(1, res.Entries.Count);
             Assert.IsInstanceOf(typeof(AstMessage), res.Entries[0]);
@@ -191,6 +191,34 @@ namespace Linguini.Syntax.Tests.Parser
                 Assert.AreEqual(identifier, message.Id.ToString());
                 Assert.AreEqual(value, numberLiteral.ToString());
             }
+        }
+
+        private const string CrlfEscape = "message = \r\n" +
+                              "  Line1\r\n" +
+                              "  \r\n" +
+                              "  \r\n" +
+                              "  Line2.\r\n";
+        
+        private const string CrEscape = "message = \n" +
+                                       "  Line1\n" +
+                                       "\n" +
+                                       "\n" +
+                                       "  Line2.\n";
+
+        private const string expected = "Line1\n\n\nLine2.";
+        
+        [Test]
+        [TestCase(CrlfEscape)]
+        // [TestCase(CrEscape)]
+        public void TestNewlinePreservation(string input)
+        {
+            var parse = new LinguiniParser(input).Parse();
+            
+            Assert.AreEqual(0, parse.Errors.Count);
+            var msg = parse.Entries[0]; 
+            Assert.IsInstanceOf(typeof(AstMessage), msg);
+            var astMsg = (AstMessage)msg;
+            Assert.AreEqual(expected,  astMsg.Debug());
         }
     }
 }

--- a/Linguini.Syntax/Ast/AstDebugHelper.cs
+++ b/Linguini.Syntax/Ast/AstDebugHelper.cs
@@ -1,0 +1,52 @@
+﻿using System.Text;
+
+namespace Linguini.Syntax.Ast
+{
+    public static class AstDebugHelper
+    {
+        public static string Debug(this AstMessage message)
+        {
+            var stringBuilder = new StringBuilder();
+            if (message.Value != null)
+            {
+                foreach (var patternElement in message.Value.Elements)
+                {
+                    switch (patternElement)
+                    {
+                        case TextLiteral textLiteral:
+                            stringBuilder.Append(textLiteral.Value);
+                            break;
+                        case Placeable placeable:
+                            Debug(placeable, stringBuilder);
+                            break;
+                    }
+                } 
+            }
+            
+            return stringBuilder.ToString();
+        }
+
+        private static void Debug(Placeable placeable, StringBuilder stringBuilder)
+        {
+            switch (placeable.Expression)
+            {
+                case SelectExpression selectExpression:
+                    Debug(selectExpression, stringBuilder);
+                    break;
+                case IInlineExpression inlineExpression:
+                    Debug(inlineExpression, stringBuilder);
+                    break;
+            }
+        }
+
+        private static void Debug(IInlineExpression inlineExpression, StringBuilder stringBuilder)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        private static void Debug(SelectExpression selectExpression, StringBuilder stringBuilder)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,33 @@
+﻿#-------------------------------------------------------------------------------#
+#               Qodana analysis is configured by qodana.yaml file               #
+#             https://www.jetbrains.com/help/qodana/qodana-yaml.html            #
+#-------------------------------------------------------------------------------#
+version: "1.0"
+
+#Specify inspection profile for code analysis
+profile:
+  name: qodana.starter
+
+#Enable inspections
+#include:
+#  - name: <SomeEnabledInspectionId>
+
+#Disable inspections
+#exclude:
+#  - name: <SomeDisabledInspectionId>
+#    paths:
+#      - <path/where/not/run/inspection>
+
+#Execute shell command before Qodana execution (Applied in CI/CD pipeline)
+#bootstrap: sh ./prepare-qodana.sh
+
+#Install IDE plugins before Qodana execution (Applied in CI/CD pipeline)
+#plugins:
+#  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)
+
+#Specify Qodana linter for analysis (Applied in CI/CD pipeline)
+linter: jetbrains/qodana-dotnet:latest
+exclude:
+  - name: All
+    paths:
+      - Linguini.Bundle\IsExternalInit.cs

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -31,3 +31,6 @@ exclude:
   - name: All
     paths:
       - Linguini.Bundle\IsExternalInit.cs
+  - name: CheckNamespace
+    paths:
+      - Linguini.Bundle\IsExternalInit.cs


### PR DESCRIPTION
The commit fixes #35.

Issue is caused by fixes introduced in #31 , where I tried to fixed line numbers on Windows, but due to tests relying on .ftl files made for Linux, they weren't caught on Windows machines. 

To solve #31 where a `Line\r\n` I added mechanism to emit lines as `Line` + MISSING_EOL flag (flag which is true for `CLRF` line endings). However a text like `  \r\n` will be treated due as `` + MISSING_EOL flag causing it to be ignored. Now these elements are no longer ignored.