### PR TITLE
V0.7.0

### DIFF
--- a/Linguini.Bundle.Test/Linguini.Bundle.Test.csproj
+++ b/Linguini.Bundle.Test/Linguini.Bundle.Test.csproj
@@ -5,6 +5,7 @@
         <Nullable>enable</Nullable>
         <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
         <OutputType>Library</OutputType>
+        <PackageVersion>0.7.0</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Linguini.Bundle/Linguini.Bundle.csproj
+++ b/Linguini.Bundle/Linguini.Bundle.csproj
@@ -18,7 +18,7 @@ It provides easy to use and extend system for describing translations.</Descript
         <Win32Resource />
         <PackageProjectUrl>https://github.com/Ygg01/Linguini</PackageProjectUrl>
         <RepositoryType>git</RepositoryType>
-        <PackageVersion>0.6.1</PackageVersion>
+        <PackageVersion>0.7.0</PackageVersion>
         <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
         <PackageIcon>linguini.jpg</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Linguini.Bundle/README.md
+++ b/Linguini.Bundle/README.md
@@ -1,2 +1,41 @@
 ﻿Linguini Bundle
+===
+
+Construct a bundle
 ---
+
+Linguini Bundle is the main API for accessing Fluent templates. It takes input, locale and useful localization
+functions.
+
+First way is to construct is using a fluent/chainable API to create a bundle.
+
+```csharp
+var bundle = LinguiniBuilder.Builder()
+    .CultureInfo(new CultureInfo("en"))
+    .AddResource("loc = Localization value")
+    .AddFunction("idfunc", (args, _) => args[0]);
+    .UncheckedBuild();
+```
+
+Here we set `loc` value for English language and pass an `idfunc` that just returns the first argument passed.
+By using `UncheckedBuild()` we get a guaranteed bundle, but any error will become an Exception. If we used `Build()`
+the result would be a tuple of type `(FluentBundle, List<FluentError>)`.
+
+Another way to construct a bundle is to provide a `FluentBundleOption`.
+
+```csharp
+var defaultBundle = new FluentBundleOption
+{
+    CultureInfo = new CultureInfo("en"),
+    Functions =
+    {
+        ["idfunc"] = (args, _) => args[0]
+    },
+    // Note no resource added!
+};
+var bundle = FluentBundle.FromBundleOptions(defaultBundleOpt);
+bundle.AddResource("loc = Localization value", out _);
+```
+
+Both methods are nearly the same, but `FluentBundleOption` doesn't provide Resources.
+They can be added vie `BundleOption`s `AddResource`.

--- a/Linguini.Serialization/Linguini.Serialization.csproj
+++ b/Linguini.Serialization/Linguini.Serialization.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <PackageVersion>0.6.0</PackageVersion>
+        <PackageVersion>0.7.0</PackageVersion>
         <TargetFramework>net6.0</TargetFramework>
         <PackageIcon>linguini.jpg</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Linguini.Shared/Linguini.Shared.csproj
+++ b/Linguini.Shared/Linguini.Shared.csproj
@@ -9,7 +9,7 @@
         <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>
         <PackageTags>fluent, i18n, internationalization, l10n, l20n, globalization, translation</PackageTags>
         <IncludeSymbols>false</IncludeSymbols>
-        <PackageVersion>0.6.0</PackageVersion>
+        <PackageVersion>0.7.0</PackageVersion>
         <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
         <PackageIcon>linguini.jpg</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Linguini.Syntax/Linguini.Syntax.csproj
+++ b/Linguini.Syntax/Linguini.Syntax.csproj
@@ -12,7 +12,7 @@
         <PackageProjectUrl>https://github.com/Ygg01/Linguini</PackageProjectUrl>
         <RepositoryType>git</RepositoryType>
         <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
-        <PackageVersion>0.6.1</PackageVersion>
+        <PackageVersion>0.7.0</PackageVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>linguini.jpg</PackageIcon>
     </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,15 @@ To install the [Fluent Bundle](https://www.nuget.org/packages/Linguini.Bundle/) 
 
 ```dotnet add package Linguini.Bundle```
 
-You can also follow other NuGet installation instructions.
+You can also follow other NuGet installation instructions. E.g. :
+
+```paket add Linguini.Bundle```
+
+Or copy this code to your [PackageReference](https://learn.microsoft.com/en-gb/nuget/consume-packages/package-references-in-project-files)
+
+```xml
+<PackageReference Include="Linguini.Bundle" Version="0.7.0" />
+```
 
 # How to use it?
 


### PR DESCRIPTION

version 0.7.0
========
- Experimental features when `UseExperimental` flag is true:
  - Dynamic Reference - ability to reference terms/message using `$$term_ref`.
    After defining it in file like so:
      ```fluent
      # example.ftl
      cat = {$number ->
          *[one] Cat
          [other] Cats
      }
      dog = {$number ->
          *[one] Dog
          [other] Dogs
      }
      attack-log = { $$attacker(number: $atk_num) } attacked {$$defender(number: $def_num)}.
      ```
      It can be called like following:
      ```csharp
      var args = new Dictionary<string, IFluentType>
      {
          ["attacker"] = (FluentReference)"cat",
          ["defender"] = (FluentReference)"dog",
      };
      Assert.True(bundle.TryGetMessage("attack-log", args, out _, out var message));
      Assert.AreEqual("Cat attacked Dog.", message);
      ```
  - Dynamic Reference attributes - You can call an attribute of a dynamic reference. It will be resolved at runtime, so
    make sure your term/message has the associated attribute.
    Example:
    ```fluent
    # dyn_attr.ftl
    -creature-elf = elf
      .StartsWith = vowel

    you-see = You see { $$object.StartsWith ->
      [vowel] an { $$object }
      *[consonant] a { $$object }
    }.
    ```
    ```csharp
    var args = new Dictionary<string, IFluentType>
    {
      ["object"] = (FluentReference)"creature-elf",
    };
    Assert.True(bundle.TryGetMessage("you-see", args, out _, out var message));
    Assert.AreEqual("You see an elf.", message);
    ```
    
  - Term passing - experimental feature allows users to override term arguments.
    ```fluent
    -ship = Ship
        .gender =  { $style ->
            *[traditional] neuter
            [chicago] feminine
        }
    ship-gender = { -ship.gender(style: $style) ->
        *[masculine] He
        [feminine] She
        [neuter] It
    }
    ```
    Usually when style isn't passed, it would to default `-ship.gender()` i.e. `neuter`, which would set `ship-gender` selector to neuter i.e. `It`.
    In above example if we set style variable to `chicago`, `-ship.gender()` it would evaluate `feminine`, so `ship-gender` would would evaluate to `She`.