### PR TITLE
AstLocation refactors

### DIFF
--- a/Linguini.Bench/BenchLinguiniParser.cs
+++ b/Linguini.Bench/BenchLinguiniParser.cs
@@ -24,7 +24,7 @@ namespace Linguini.Bench
             LinguiniParser parser;
             for (int i = 0; i < N; i++)
             {
-                parser = new LinguiniParser(_largeFtl);
+                parser = LinguiniParser.FromFragment(_largeFtl, "bench_ftl/large.ftl");
                 parser.Parse();
             }
         }

--- a/Linguini.Bundle/Builder/FluentBundleOption.cs
+++ b/Linguini.Bundle/Builder/FluentBundleOption.cs
@@ -73,7 +73,8 @@ namespace Linguini.Bundle.Builder
             new Dictionary<string, ExternalFunction>();
 
         /// <summary>
-        /// Gets or sets the formatter function that is used to format Fluent type values into strings.
+        /// Gets or sets the formatter function that is used to format Fluent type values into strings,
+        /// allowing for type specific formatting.
         /// </summary>
         /// <remarks>
         /// The formatter function takes an instance of <see cref="IFluentType"/> and returns the string representation of the value.
@@ -86,8 +87,10 @@ namespace Linguini.Bundle.Builder
         /// </value>
         public Func<IFluentType, string>? FormatterFunc { get; init; }
 
+        
+
         /// <summary>
-        /// Represents a function that transforms a string value before it is used in Fluent message formatting.
+        /// Represents a function that transforms all textual fragment during formatting.
         /// </summary>
         /// <value>The transformed string value.</value>
         public Func<string, string>? TransformFunc { get; init; }

--- a/Linguini.Bundle/Builder/LinguiniBuilder.cs
+++ b/Linguini.Bundle/Builder/LinguiniBuilder.cs
@@ -61,33 +61,89 @@ namespace Linguini.Bundle.Builder
 
         public interface IResourceStep : IStep
         {
-            [Obsolete("Consider using IResourceStep.AddFiles(IEnumerable<string>)")]
+            /// <summary>
+            /// Adds <see cref="IEnumerable{T}"/> of fragments to a <see cref="FluentBundle"/>.
+            /// </summary>
+            /// <param name="unparsedResourceList">Enumerable of string fragments</param>
+            /// <returns>The <see cref="IReadyStep">next step (final)</see> in the builder.</returns>
             IReadyStep AddResources(IEnumerable<string> unparsedResourceList);
 
-            [Obsolete("Consider using IResourceStep.AddFiles(IEnumerable<string>)")]
+            /// <summary>
+            /// Adds <see cref="IEnumerable{T}"/> of fragments to a <see cref="FluentBundle"/>.
+            /// </summary>
+            /// <param name="unparsedResourceArray">String array of string fragments</param>
+            /// <returns>The <see cref="IReadyStep">next step (final)</see> in the builder.</returns>
             IReadyStep AddResources(params string[] unparsedResourceArray);
 
-            [Obsolete]
+            [Obsolete("Method is obsolete, please use IResourceStep.AddResources(IEnumerable<(TextReader, string?)>) instead.", true)]
             IReadyStep AddResources(IEnumerable<TextReader> unparsedStreamList);
 
-            [Obsolete]
+            [Obsolete("Method is obsolete, please use IResourceStep.AddResources(params (TextReader, string?)[]) instead.", true)]
             IReadyStep AddResources(params TextReader[] unparsedStreamList);
 
+            /// <summary>
+            /// Adds a fragments to a <see cref="FluentBundle"/>. 
+            /// </summary>
+            /// <param name="resource">Content of a resource</param>
+            /// <param name="filename">Quasi file name used to identify the fragment</param>
+            /// <returns>The <see cref="IReadyStep">next step (final)</see> in the builder.</returns>
             IReadyStep AddResource(string resource, string? filename = null);
 
+            /// <summary>
+            /// Adds a fragments to a <see cref="FluentBundle"/>. 
+            /// </summary>
+            /// <param name="resource">TextReader content of a resource</param>
+            /// <param name="filename">Quasi file name used to identify the fragment</param>
+            /// <returns>The <see cref="IReadyStep">next step (final)</see> in the builder.</returns>
             IReadyStep AddResource(TextReader resource, string? filename = null);
 
-
+            /// <summary>
+            /// Adds a <see cref="TextReader"/> to a <see cref="FluentBundle"/>. 
+            /// </summary>
+            /// <param name="readerList">Array of <see cref="TextReader"/> and an optional file name.</param>
+            /// <returns>The <see cref="IReadyStep">next step (final)</see> in the builder.</returns>
             IReadyStep AddResources(params (TextReader, string?)[] readerList);
 
+            /// <summary>
+            /// Adds a <see cref="TextReader"/> to a <see cref="FluentBundle"/>. 
+            /// </summary>
+            /// <param name="readerList"><see cref="IEnumerable{T}"/> of <see cref="TextReader"/> and an optional file name.</param>
+            /// <returns>The <see cref="IReadyStep">next step (final)</see> in the builder.</returns>
             IReadyStep AddResources(IEnumerable<(TextReader, string?)> readerList);
 
+            /// <summary>
+            /// Adds a file to a <see cref="FluentBundle"/>. 
+            /// </summary>
+            /// <param name="path">A file on a path.</param>
+            /// <returns>The <see cref="IReadyStep">next step (final)</see> in the builder.</returns>
             IReadyStep AddFile(string path);
 
+            /// <summary>
+            /// Adds several files to a <see cref="FluentBundle"/>. 
+            /// </summary>
+            /// <param name="paths">An array of file paths.</param>
+            /// <returns>The <see cref="IReadyStep">next step (final)</see> in the builder.</returns>
             IReadyStep AddFiles(params string[] paths);
 
-            IReadyStep AddFiles(IEnumerable<string> path);
+            /// <summary>
+            /// Adds several files to a <see cref="FluentBundle"/>. 
+            /// </summary>
+            /// <param name="paths">An <see cref="Enumerable"/> of file paths.</param>
+            /// <returns>The <see cref="IReadyStep">next step (final)</see> in the builder.</returns>
+            IReadyStep AddFiles(IEnumerable<string> paths);
+
+            /// <summary>
+            /// Adds several parsed resources to a <see cref="FluentBundle"/>. 
+            /// </summary>
+            /// <param name="resources">An <see cref="Enumerable"/> of <see cref="Resource"/> that are added to the bundle.</param>
+            /// <returns>The <see cref="IReadyStep">next step (final)</see> in the builder.</returns>
             IReadyStep AddResources(IEnumerable<Resource> resources);
+            
+            /// <summary>
+            /// Adds several parsed resources to a <see cref="FluentBundle"/>. 
+            /// </summary>
+            /// <param name="resources">An array of <see cref="Resource"/> that are added to the bundle.</param>
+            /// <returns>The <see cref="IReadyStep">next step (final)</see> in the builder.</returns>
             IReadyStep AddResources(params Resource[] resources);
 
             /// <summary>

--- a/Linguini.Bundle/Builder/LinguiniBuilder.cs
+++ b/Linguini.Bundle/Builder/LinguiniBuilder.cs
@@ -46,7 +46,7 @@ namespace Linguini.Bundle.Builder
             /// <summary>
             /// Sets the locale chain to given <c>params string[]</c> of locale string.
             /// </summary>
-            /// <param name="unparsedLocales">The variable argument string uost.</param>
+            /// <param name="unparsedLocales">The variable argument string list.</param>
             /// <returns>The <see cref="IResourceStep">next step (defining resources)</see> in the builder.</returns>
             IResourceStep Locales(params string[] unparsedLocales);
 
@@ -61,10 +61,10 @@ namespace Linguini.Bundle.Builder
 
         public interface IResourceStep : IStep
         {
-            [Obsolete]
+            [Obsolete("Consider using IResourceStep.AddFiles(IEnumerable<string>)")]
             IReadyStep AddResources(IEnumerable<string> unparsedResourceList);
 
-            [Obsolete]
+            [Obsolete("Consider using IResourceStep.AddFiles(IEnumerable<string>)")]
             IReadyStep AddResources(params string[] unparsedResourceArray);
 
             [Obsolete]

--- a/Linguini.Bundle/Builder/LinguiniBuilder.cs
+++ b/Linguini.Bundle/Builder/LinguiniBuilder.cs
@@ -79,13 +79,13 @@ namespace Linguini.Bundle.Builder
 
 
             IReadyStep AddResources(params (TextReader, string?)[] readerList);
-            
+
             IReadyStep AddResources(IEnumerable<(TextReader, string?)> readerList);
 
             IReadyStep AddFile(string path);
-            
-            IReadyStep AddFiles(params string[] path);
-            
+
+            IReadyStep AddFiles(params string[] paths);
+
             IReadyStep AddFiles(IEnumerable<string> path);
             IReadyStep AddResources(IEnumerable<Resource> resources);
             IReadyStep AddResources(params Resource[] resources);
@@ -312,39 +312,78 @@ namespace Linguini.Bundle.Builder
                 return this;
             }
 
+            /// <inheritdoc/>
             public IReadyStep AddResource(string resource, string? filename = null)
             {
-                throw new NotImplementedException();
+                var parsed = LinguiniParser.FromFragment(resource, filename, _enableExperimental).Parse();
+                _resources.Add(parsed);
+                return this;
             }
 
+            /// <inheritdoc/>
             public IReadyStep AddResource(TextReader resource, string? filename = null)
             {
-                throw new NotImplementedException();
+                var parsed = LinguiniParser.FromTextReader(resource, filename ?? "????", _enableExperimental).Parse();
+                _resources.Add(parsed);
+
+                return this;
             }
 
-            public IReadyStep AddResources(params (TextReader, string?)[] readerList)
+            /// <inheritdoc/>
+            public IReadyStep AddResources(params (TextReader, string?)[] unparsedStreamList)
             {
-                throw new NotImplementedException();
+                foreach (var (reader, inputName) in unparsedStreamList)
+                {
+                    var parsed = LinguiniParser.FromTextReader(reader, inputName ?? "???", _enableExperimental).Parse();
+                    _resources.Add(parsed);
+                }
+
+                return this;
             }
 
-            public IReadyStep AddResources(IEnumerable<(TextReader, string?)> readerList)
+            /// <inheritdoc/>
+            public IReadyStep AddResources(IEnumerable<(TextReader, string?)> unparsedStreamList)
             {
-                throw new NotImplementedException();
+                foreach (var (reader, inputName) in unparsedStreamList)
+                {
+                    var parsed = LinguiniParser.FromTextReader(reader, inputName ?? "???", _enableExperimental).Parse();
+                    _resources.Add(parsed);
+                }
+
+                return this;
             }
 
+            /// <inheritdoc/>
             public IReadyStep AddFile(string path)
             {
-                throw new NotImplementedException();
+                var parsed = LinguiniParser.FromFile(path, _enableExperimental).Parse();
+                _resources.Add(parsed);
+
+                return this;
             }
 
-            public IReadyStep AddFiles(params string[] path)
+            /// <inheritdoc/>
+            public IReadyStep AddFiles(params string[] paths)
             {
-                throw new NotImplementedException();
+                foreach (var path in paths)
+                {
+                    var parsed = LinguiniParser.FromFile(path).Parse();
+                    _resources.Add(parsed);
+                }
+
+                return this;
             }
 
-            public IReadyStep AddFiles(IEnumerable<string> path)
+            /// <inheritdoc/>
+            public IReadyStep AddFiles(IEnumerable<string> paths)
             {
-                throw new NotImplementedException();
+                foreach (var path in paths)
+                {
+                    var parsed = LinguiniParser.FromFile(path).Parse();
+                    _resources.Add(parsed);
+                }
+
+                return this;
             }
 
             /// <inheritdoc/>

--- a/Linguini.Bundle/Builder/LinguiniBuilder.cs
+++ b/Linguini.Bundle/Builder/LinguiniBuilder.cs
@@ -198,23 +198,24 @@ namespace Linguini.Bundle.Builder
 
             public IReadyStep AddResource(string unparsed)
             {
-                var resource = new LinguiniParser(unparsed, _enableExperimental).Parse();
+                var resource = LinguiniParser.FromFragment(unparsed, enableExperimental: _enableExperimental).Parse();
                 _resources.Add(resource);
                 return this;
             }
 
             public IReadyStep AddResource(TextReader unparsed)
             {
-                var resource = new LinguiniParser(unparsed, _enableExperimental).Parse();
+                var resource = LinguiniParser.FromTextReader(unparsed,  "????", _enableExperimental).Parse();
                 _resources.Add(resource);
                 return this;
             }
 
+            [Obsolete]
             public IReadyStep AddResources(params TextReader[] unparsedStreamList)
             {
                 foreach (var unparsed in unparsedStreamList)
                 {
-                    var parsed = new LinguiniParser(unparsed, _enableExperimental).Parse();
+                    var parsed = LinguiniParser.FromTextReader(unparsed, "???", _enableExperimental).Parse();
                     _resources.Add(parsed);
                 }
 
@@ -225,7 +226,7 @@ namespace Linguini.Bundle.Builder
             {
                 foreach (var unparsed in unparsedResources)
                 {
-                    var parsed = new LinguiniParser(unparsed, _enableExperimental).Parse();
+                    var parsed = LinguiniParser.FromFragment(unparsed, enableExperimental: _enableExperimental).Parse();
                     _resources.Add(parsed);
                 }
 
@@ -236,7 +237,7 @@ namespace Linguini.Bundle.Builder
             {
                 foreach (var unparsed in unparsedResourceArray)
                 {
-                    var parsed = new LinguiniParser(unparsed, _enableExperimental).Parse();
+                    var parsed = LinguiniParser.FromFragment(unparsed, enableExperimental: _enableExperimental).Parse();
                     _resources.Add(parsed);
                 }
 
@@ -247,7 +248,7 @@ namespace Linguini.Bundle.Builder
             {
                 foreach (var unparsed in unparsedStream)
                 {
-                    var parsed = new LinguiniParser(unparsed, _enableExperimental).Parse();
+                    var parsed = LinguiniParser.FromTextReader(unparsed, "???", enableExperimental: _enableExperimental).Parse();
                     _resources.Add(parsed);
                 }
 

--- a/Linguini.Bundle/Builder/LinguiniBuilder.cs
+++ b/Linguini.Bundle/Builder/LinguiniBuilder.cs
@@ -17,6 +17,7 @@ namespace Linguini.Bundle.Builder
         /// Builder class for constructing Fluent bundles.
         /// </summary>
         /// <param name="useExperimental">Sets the <see cref="FluentBundleOption.EnableExtensions"/> flag. Defaults to <c>false</c></param>
+        /// <returns>The <see cref="ILocaleStep">next step (locale setting)</see> in the builder.</returns>
         public static ILocaleStep Builder(bool useExperimental = false)
         {
             return new StepBuilder(useExperimental);
@@ -28,40 +29,131 @@ namespace Linguini.Bundle.Builder
 
         public interface ILocaleStep : IStep
         {
+            /// <summary>
+            /// Sets the locale to given string.
+            /// </summary>
+            /// <param name="unparsedLocale">The locale string.</param>
+            /// <returns>The <see cref="IResourceStep">next step (defining resources)</see> in the builder.</returns>
             IResourceStep Locale(string unparsedLocale);
+
+            /// <summary>
+            /// Sets the locale chain to given <c>IEnumerable&lt;string&gt;</c> of locale strings.
+            /// </summary>
+            /// <param name="unparsedLocales">The locale list.</param>
+            /// <returns>The <see cref="IResourceStep">next step (defining resources)</see> in the builder.</returns>
             IResourceStep Locales(IEnumerable<string> unparsedLocales);
+
+            /// <summary>
+            /// Sets the locale chain to given <c>params string[]</c> of locale string.
+            /// </summary>
+            /// <param name="unparsedLocales">The variable argument string uost.</param>
+            /// <returns>The <see cref="IResourceStep">next step (defining resources)</see> in the builder.</returns>
             IResourceStep Locales(params string[] unparsedLocales);
 
+
+            /// <summary>
+            /// Sets the locale to given <see cref="CultureInfo"/>.
+            /// </summary>
+            /// <param name="culture">The default <see cref="CultureInfo"/> of Bundle.</param>
+            /// <returns>The <see cref="IResourceStep">next step (defining resources)</see> in the builder.</returns>
             IResourceStep CultureInfo(CultureInfo culture);
         }
 
         public interface IResourceStep : IStep
         {
+            [Obsolete]
             IReadyStep AddResources(IEnumerable<string> unparsedResourceList);
+
+            [Obsolete]
             IReadyStep AddResources(params string[] unparsedResourceArray);
+
+            [Obsolete]
             IReadyStep AddResources(IEnumerable<TextReader> unparsedStreamList);
+
+            [Obsolete]
             IReadyStep AddResources(params TextReader[] unparsedStreamList);
-            IReadyStep AddResource(string resource);
-            IReadyStep AddResource(TextReader resource);
+
+            IReadyStep AddResource(string resource, string? filename = null);
+
+            IReadyStep AddResource(TextReader resource, string? filename = null);
+
+
+            IReadyStep AddResources(params (TextReader, string?)[] readerList);
+            
+            IReadyStep AddResources(IEnumerable<(TextReader, string?)> readerList);
+
+            IReadyStep AddFile(string path);
+            
+            IReadyStep AddFiles(params string[] path);
+            
+            IReadyStep AddFiles(IEnumerable<string> path);
             IReadyStep AddResources(IEnumerable<Resource> resources);
             IReadyStep AddResources(params Resource[] resources);
+
+            /// <summary>
+            /// Skip the resource adding step.
+            /// </summary>
+            /// <returns>The <see cref="IReadyStep">next step (final)</see></returns>
             IReadyStep SkipResources();
         }
 
-        public interface IBuildStep : IStep
-        {
-            FluentBundle UncheckedBuild();
-
-            (FluentBundle, List<FluentError>?) Build();
-        }
 
         public interface IReadyStep : IBuildStep
         {
+            /// <summary>
+            /// Sets Bidirectional isolation for bundle. See <see cref="FluentBundleOption.UseIsolating">FluentBundleOption.UseIsolating</see>
+            /// </summary>
+            /// <param name="isIsolating">Sets BiDi isolation for bundle.</param>
+            /// <returns>The next step in the builder.</returns>
             IReadyStep SetUseIsolating(bool isIsolating);
+
+            /// <summary>
+            /// Sets the transformation function. See <see cref="FluentBundleOption.TransformFunc">FluentBundleOption.TransformFunc</see>.
+            /// </summary>
+            /// <param name="transformFunc">Transform function, which transforms text fragments into another string.</param>
+            /// <returns>The next step in the builder.</returns>
             IReadyStep SetTransformFunc(Func<string, string> transformFunc);
+
+            /// <summary>
+            /// Sets the formatter function. See <see cref="FluentBundleOption.FormatterFunc">FluentBundleOption.FormatterFunc</see>.
+            /// </summary>
+            /// <param name="formatterFunc">Formater function which can specify type specific formatters.</param>
+            /// <returns>The next step in the builder.</returns>
             IReadyStep SetFormatterFunc(Func<IFluentType, string> formatterFunc);
+
+            /// <summary>
+            /// Adds a function to the FluentBundle.
+            /// </summary>
+            /// <param name="name">The name of the custom function.</param>
+            /// <param name="externalFunction">The delegate that represents the function.</param>
+            /// <returns>The next step in the builder.</returns>
             IReadyStep AddFunction(string name, ExternalFunction externalFunction);
+
+            /// <summary>
+            /// Makes current bundle builder concurrent.
+            /// </summary>
+            /// <returns>The next step in the builder.</returns>
             IReadyStep UseConcurrent();
+        }
+
+        /// <summary>
+        /// Final step of Builder, constructs <see cref="FluentBundle"/>.
+        /// </summary>
+        public interface IBuildStep : IStep
+        {
+            /// <summary>
+            /// Finalizes the build by creating a <see cref="FluentBundle"/>. Throws exception is any errors
+            /// occured.
+            /// </summary>
+            /// <exception cref="LinguiniException">If there was an error during build.</exception>
+            /// <returns>Completed <see cref="FluentBundle"/></returns>
+            FluentBundle UncheckedBuild();
+
+            /// <summary>
+            /// Finalizes the build by creating a tuple of <see cref="FluentBundle"/> and errors encountered.
+            /// </summary>
+            /// <returns>Completed <see cref="FluentBundle"/></returns>
+            (FluentBundle, List<FluentError>?) Build();
         }
 
         private class StepBuilder : IReadyStep, ILocaleStep, IResourceStep
@@ -76,42 +168,49 @@ namespace Linguini.Bundle.Builder
             private bool _concurrent;
             private readonly bool _enableExperimental;
 
+
             internal StepBuilder(bool useExperimental = false)
             {
                 _culture = System.Globalization.CultureInfo.CurrentCulture;
                 _enableExperimental = useExperimental;
             }
 
+            /// <inheritdoc/>
             public IReadyStep SetUseIsolating(bool isIsolating)
             {
                 _useIsolating = isIsolating;
                 return this;
             }
 
+            /// <inheritdoc/>
             public IReadyStep SetTransformFunc(Func<string, string> transformFunc)
             {
                 _transformFunc = transformFunc;
                 return this;
             }
 
+            /// <inheritdoc/>
             public IReadyStep SetFormatterFunc(Func<IFluentType, string> formatterFunc)
             {
                 _formatterFunc = formatterFunc;
                 return this;
             }
 
+            /// <inheritdoc/>
             public IReadyStep AddFunction(string name, ExternalFunction externalFunction)
             {
                 _functions[name] = externalFunction;
                 return this;
             }
 
+            /// <inheritdoc/>
             public IReadyStep UseConcurrent()
             {
                 _concurrent = true;
                 return this;
             }
 
+            /// <inheritdoc/>
             public FluentBundle UncheckedBuild()
             {
                 var (bundle, errors) = Build();
@@ -124,6 +223,7 @@ namespace Linguini.Bundle.Builder
                 return bundle;
             }
 
+            /// <inheritdoc/>
             public (FluentBundle, List<FluentError>?) Build()
             {
                 var concurrent = new FluentBundleOption
@@ -161,6 +261,7 @@ namespace Linguini.Bundle.Builder
                 return (bundle, errors);
             }
 
+            /// <inheritdoc/>
             public IResourceStep Locale(string unparsedLocale)
             {
                 _culture = new CultureInfo(unparsedLocale);
@@ -168,11 +269,13 @@ namespace Linguini.Bundle.Builder
                 return this;
             }
 
+            /// <inheritdoc/>
             public IResourceStep Locales(IEnumerable<string> unparsedLocales)
             {
                 return Locales(unparsedLocales.ToArray());
             }
 
+            /// <inheritdoc/>
             public IResourceStep Locales(params string[] unparsedLocales)
             {
                 _locales.AddRange(unparsedLocales);
@@ -189,6 +292,7 @@ namespace Linguini.Bundle.Builder
                 return this;
             }
 
+            /// <inheritdoc/>
             public IResourceStep CultureInfo(CultureInfo culture)
             {
                 _culture = culture;
@@ -196,21 +300,7 @@ namespace Linguini.Bundle.Builder
                 return this;
             }
 
-            public IReadyStep AddResource(string unparsed)
-            {
-                var resource = LinguiniParser.FromFragment(unparsed, enableExperimental: _enableExperimental).Parse();
-                _resources.Add(resource);
-                return this;
-            }
-
-            public IReadyStep AddResource(TextReader unparsed)
-            {
-                var resource = LinguiniParser.FromTextReader(unparsed,  "????", _enableExperimental).Parse();
-                _resources.Add(resource);
-                return this;
-            }
-
-            [Obsolete]
+            /// <inheritdoc/>
             public IReadyStep AddResources(params TextReader[] unparsedStreamList)
             {
                 foreach (var unparsed in unparsedStreamList)
@@ -222,6 +312,42 @@ namespace Linguini.Bundle.Builder
                 return this;
             }
 
+            public IReadyStep AddResource(string resource, string? filename = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IReadyStep AddResource(TextReader resource, string? filename = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IReadyStep AddResources(params (TextReader, string?)[] readerList)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IReadyStep AddResources(IEnumerable<(TextReader, string?)> readerList)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IReadyStep AddFile(string path)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IReadyStep AddFiles(params string[] path)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IReadyStep AddFiles(IEnumerable<string> path)
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <inheritdoc/>
             public IReadyStep AddResources(IEnumerable<string> unparsedResources)
             {
                 foreach (var unparsed in unparsedResources)
@@ -233,6 +359,7 @@ namespace Linguini.Bundle.Builder
                 return this;
             }
 
+            /// <inheritdoc/>
             public IReadyStep AddResources(params string[] unparsedResourceArray)
             {
                 foreach (var unparsed in unparsedResourceArray)
@@ -244,29 +371,34 @@ namespace Linguini.Bundle.Builder
                 return this;
             }
 
+            /// <inheritdoc/>
             public IReadyStep AddResources(IEnumerable<TextReader> unparsedStream)
             {
                 foreach (var unparsed in unparsedStream)
                 {
-                    var parsed = LinguiniParser.FromTextReader(unparsed, "???", enableExperimental: _enableExperimental).Parse();
+                    var parsed = LinguiniParser.FromTextReader(unparsed, "???", enableExperimental: _enableExperimental)
+                        .Parse();
                     _resources.Add(parsed);
                 }
 
                 return this;
             }
 
+            /// <inheritdoc/>
             public IReadyStep AddResources(IEnumerable<Resource> parsedResource)
             {
                 _resources.AddRange(parsedResource);
                 return this;
             }
 
+            /// <inheritdoc/>
             public IReadyStep AddResources(params Resource[] resources)
             {
                 _resources.AddRange(resources);
                 return this;
             }
 
+            /// <inheritdoc/>
             public IReadyStep SkipResources()
             {
                 return this;

--- a/Linguini.Bundle/Errors/FluentError.cs
+++ b/Linguini.Bundle/Errors/FluentError.cs
@@ -27,8 +27,6 @@ namespace Linguini.Bundle.Errors
             return null;
         }
 
-
-
         /// <summary>
         /// String representation of the error.
         /// </summary>
@@ -134,7 +132,7 @@ namespace Linguini.Bundle.Errors
 
         public static ResolverFluentError TooManyPlaceables(string? location = null)
         {
-            return new("Too many placeables", ErrorType.TooManyPlaceables,  location);
+            return new("Too many placeables", ErrorType.TooManyPlaceables, location);
         }
 
         public static ResolverFluentError Reference(IInlineExpression self, string? location = null)
@@ -223,7 +221,7 @@ namespace Linguini.Bundle.Errors
             {
                 AstTerm => EntryKind.Term,
                 AstMessage => EntryKind.Message,
-                _ =>  EntryKind.Func
+                _ => EntryKind.Func
             };
         }
     }

--- a/Linguini.Bundle/FluentBundle.cs
+++ b/Linguini.Bundle/FluentBundle.cs
@@ -172,7 +172,7 @@ namespace Linguini.Bundle
         /// <seealso cref="AddResource(string,out System.Collections.Generic.List{Linguini.Bundle.Errors.FluentError}?)"/>
         public bool AddResource(string input, [NotNullWhen(false)] out List<FluentError>? errors)
         {
-            var res = new LinguiniParser(input, EnableExtensions).Parse();
+            var res = LinguiniParser.FromFragment(input, enableExperimental: EnableExtensions).Parse();
             return AddResource(res, out errors);
         }
 
@@ -181,11 +181,13 @@ namespace Linguini.Bundle
         /// </summary>
         /// <param name="reader">The <see cref="TextReader"/> representing the Fluent resource.</param>
         /// <param name="errors">The list of Fluent errors, if any.</param>
+        /// <param name="inputName">Name of text reader if possible</param>
         /// <returns>True if the resource was added successfully; otherwise, false.</returns>
         /// <seealso cref="AddResource(string,out System.Collections.Generic.List{Linguini.Bundle.Errors.FluentError}?)"/>
-        public bool AddResource(TextReader reader, [NotNullWhen(false)] out List<FluentError>? errors)
+        public bool AddResource(TextReader reader, [NotNullWhen(false)] out List<FluentError>? errors,
+            string? inputName = "????")
         {
-            var res = new LinguiniParser(reader, EnableExtensions).Parse();
+            var res = LinguiniParser.FromTextReader(reader, inputName, enableExperimental: EnableExtensions).Parse();
             return AddResource(res, out errors);
         }
 
@@ -244,7 +246,7 @@ namespace Linguini.Bundle
         /// <param name="input">The resource content to add.</param>
         public void AddResourceOverriding(string input)
         {
-            var res = new LinguiniParser(input, EnableExtensions).Parse();
+            var res = LinguiniParser.FromFragment(input: input, enableExperimental: EnableExtensions).Parse();
             AddResourceOverriding(res);
         }
 
@@ -252,9 +254,9 @@ namespace Linguini.Bundle
         /// Adds a <see cref="TextReader"/> to the FluentBundle, overriding any existing messages and terms with the same identifiers.
         /// </summary>
         /// <param name="input">The text reader to be added to parsed and added to bundle.</param>
-        public void AddResourceOverriding(TextReader input)
+        public void AddResourceOverriding(TextReader input, string filename = "????")
         {
-            var res = new LinguiniParser(input, EnableExtensions).Parse();
+            var res = LinguiniParser.FromTextReader(input, filename, enableExperimental: EnableExtensions).Parse();
             AddResourceOverriding(res);
         }
         

--- a/Linguini.Serialization.Test/SerializeAndDeserializeTest.cs
+++ b/Linguini.Serialization.Test/SerializeAndDeserializeTest.cs
@@ -57,7 +57,7 @@ public class SerializeAndDeserializeTest
                 new("attr1", new PatternBuilder("value1")),
                 new("attr2", new PatternBuilder("value2"))
             }, 
-            AstLocation.EMPTY, 
+            AstLocation.Empty, 
             new(CommentLevel.ResourceComment, new()
             {
                 "test".AsMemory()

--- a/Linguini.Serialization.Test/SerializeAndDeserializeTest.cs
+++ b/Linguini.Serialization.Test/SerializeAndDeserializeTest.cs
@@ -57,6 +57,7 @@ public class SerializeAndDeserializeTest
                 new("attr1", new PatternBuilder("value1")),
                 new("attr2", new PatternBuilder("value2"))
             }, 
+            AstLocation.EMPTY, 
             new(CommentLevel.ResourceComment, new()
             {
                 "test".AsMemory()

--- a/Linguini.Serialization/Converters/MessageSerializer.cs
+++ b/Linguini.Serialization/Converters/MessageSerializer.cs
@@ -40,7 +40,7 @@ namespace Linguini.Serialization.Converters
                 }
             }
 
-            return new AstMessage(identifier, value, attrs, AstLocation.EMPTY, comment);
+            return new AstMessage(identifier, value, attrs, AstLocation.Empty, comment);
         }
 
         public override void Write(Utf8JsonWriter writer, AstMessage msg, JsonSerializerOptions options)

--- a/Linguini.Serialization/Converters/MessageSerializer.cs
+++ b/Linguini.Serialization/Converters/MessageSerializer.cs
@@ -40,7 +40,7 @@ namespace Linguini.Serialization.Converters
                 }
             }
 
-            return new AstMessage(identifier, value, attrs, comment);
+            return new AstMessage(identifier, value, attrs, AstLocation.EMPTY, comment);
         }
 
         public override void Write(Utf8JsonWriter writer, AstMessage msg, JsonSerializerOptions options)

--- a/Linguini.Syntax.Tests/Parser/LinguiniFtlParserTest.cs
+++ b/Linguini.Syntax.Tests/Parser/LinguiniFtlParserTest.cs
@@ -78,23 +78,13 @@ namespace Linguini.Syntax.Tests.Parser
 
         private static Resource ParseFtlFile(string path, bool enableExtensions = false)
         {
-            LinguiniParser parser;
-            using (var reader = new StreamReader(path))
-            {
-                parser = new LinguiniParser(reader, enableExtensions);
-            }
-
+            LinguiniParser parser = LinguiniParser.FromFile(path, enableExtensions);
             return parser.ParseWithComments();
         }
 
         private static Resource ParseFtlFileFast(string path, bool enableExtensions = false)
         {
-            LinguiniParser parser;
-            using (var reader = new StreamReader(path))
-            {
-                parser = new LinguiniParser(reader, enableExtensions);
-            }
-
+            LinguiniParser parser = LinguiniParser.FromFile(path, enableExtensions);
             return parser.Parse();
         }
 

--- a/Linguini.Syntax.Tests/Parser/LinguiniParserTest.cs
+++ b/Linguini.Syntax.Tests/Parser/LinguiniParserTest.cs
@@ -28,7 +28,8 @@ namespace Linguini.Syntax.Tests.Parser
         public void TestCommentParse(string input, CommentLevel expectedCommentLevel = CommentLevel.Comment,
             string expectedContent = "Comment")
         {
-            Resource parsed = new LinguiniParser(input).ParseWithComments();
+            Resource parsed = LinguiniParser.FromFragment(input).ParseWithComments();
+
             Assert.That(parsed.Entries.Count, Is.EqualTo(1));
             if (parsed.Entries[0] is AstComment comment)
             {
@@ -52,7 +53,7 @@ namespace Linguini.Syntax.Tests.Parser
         public void TestErrorCommentParse(string input, ErrorType expErrType, string expMsg, int start, int end,
             int sliceStart, int sliceEnd)
         {
-            Resource parsed = new LinguiniParser(input).ParseWithComments();
+            var parsed = LinguiniParser.FromFragment(input).ParseWithComments();
             Assert.That(parsed.Errors.Count, Is.EqualTo(1));
             Assert.That(expErrType, Is.EqualTo(parsed.Errors[0].Kind));
             Assert.That(expMsg, Is.EqualTo(parsed.Errors[0].Message));
@@ -77,7 +78,7 @@ namespace Linguini.Syntax.Tests.Parser
         [TestCase("a=\n\n  bar\n  baz", "a", "bar\nbaz")]
         public void TestMessageParse(string input, string expName, string expValue)
         {
-            Resource parsed = new LinguiniParser(input).ParseWithComments();
+            var parsed = LinguiniParser.FromFragment(input).ParseWithComments();
             Assert.That(0, Is.EqualTo(parsed.Errors.Count), "Failed, with errors");
             Assert.That(1, Is.EqualTo(parsed.Entries.Count));
             if (parsed.Entries[0] is AstMessage { Value: { } } message)
@@ -100,7 +101,7 @@ namespace Linguini.Syntax.Tests.Parser
         public void TestMessageComment(string input, bool inMessage, string expMsg, string expComment)
         {
             var expBodySize = inMessage ? 1 : 2;
-            Resource parsed = new LinguiniParser(input).ParseWithComments();
+            var parsed = LinguiniParser.FromFragment(input).ParseWithComments();
             Assert.That(parsed.Errors.Count, Is.EqualTo(0));
             Assert.That(parsed.Entries.Count, Is.EqualTo(expBodySize));
             if (inMessage)
@@ -138,7 +139,7 @@ namespace Linguini.Syntax.Tests.Parser
 
         {
             var expBodySize = inTerm ? 1 : 2;
-            Resource parsed = new LinguiniParser(input).ParseWithComments();
+            var parsed = LinguiniParser.FromFragment(input).ParseWithComments();
             Assert.That(0, Is.EqualTo(parsed.Errors.Count));
             Assert.That(expBodySize, Is.EqualTo(parsed.Entries.Count));
             if (inTerm)
@@ -174,16 +175,16 @@ namespace Linguini.Syntax.Tests.Parser
         [TestCase("num = {123}", "num", "123")]
         public void TestNumExpressions(string input, string identifier, string value)
         {
-            var res = new LinguiniParser(input).Parse();
+            var res = LinguiniParser.FromFragment(input).Parse();
 
             Assert.That(0, Is.EqualTo(res.Errors.Count));
             Assert.That(1, Is.EqualTo(res.Entries.Count));
             Assert.That(res.Entries[0], Is.InstanceOf<AstMessage>());
-            
+
             if (res.Entries[0] is not AstMessage message
                 || message.Value.Elements[0] is not Placeable placeable
                 || placeable.Expression is not NumberLiteral numberLiteral) return;
-            
+
             Assert.That(1, Is.EqualTo(message.Value.Elements.Count));
             Assert.That(message.Value.Elements[0], Is.InstanceOf<Placeable>());
             Assert.That(placeable, Is.Not.Null);
@@ -212,7 +213,7 @@ namespace Linguini.Syntax.Tests.Parser
         // [TestCase(CrEscape)]
         public void TestNewlinePreservation(string input)
         {
-            var parse = new LinguiniParser(input).Parse();
+            var parse = LinguiniParser.FromFragment(input, "TestNewLinePreservation").Parse();
 
             Assert.That(0, Is.EqualTo(parse.Errors.Count));
             var msg = parse.Entries[0];

--- a/Linguini.Syntax.Tests/Parser/LinguiniTestDetailedErrors.cs
+++ b/Linguini.Syntax.Tests/Parser/LinguiniTestDetailedErrors.cs
@@ -12,8 +12,8 @@ namespace Linguini.Syntax.Tests.Parser
         public void TestDetailedErrors(string input, int row, int startErr, int endErr,
             int startMark, int endMark)
         {
-            var parse = new LinguiniParser(input).Parse();
-            var parseWithComments = new LinguiniParser(input).ParseWithComments();
+            var parse = LinguiniParser.FromFragment(input).Parse();
+            var parseWithComments = LinguiniParser.FromFragment(input).ParseWithComments();
 
             Assert.That(1, Is.EqualTo(parse.Errors.Count));
             Assert.That(1, Is.EqualTo(parseWithComments.Errors.Count));
@@ -36,7 +36,7 @@ foo = {
 d = e
 ";
 
-            var parser = new LinguiniParser(code);
+            var parser = LinguiniParser.FromFragment(code, "TestLineOffset");
             var result = parser.Parse();
             var error = result.Errors[0];
 

--- a/Linguini.Syntax/Ast/Entry.cs
+++ b/Linguini.Syntax/Ast/Entry.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Linguini.Syntax.IO;
 using Linguini.Syntax.Parser.Error;
 
 namespace Linguini.Syntax.Ast
@@ -21,17 +22,20 @@ namespace Linguini.Syntax.Ast
     public class AstMessage : IEntry, IEquatable<AstMessage>
     {
         public readonly Identifier Id;
+        public readonly AstLocation Location;
         public readonly Pattern? Value;
         public readonly List<Attribute> Attributes;
 
         public AstComment? Comment => InternalComment;
         protected internal AstComment? InternalComment;
 
-        public AstMessage(Identifier id, Pattern? pattern, List<Attribute> attrs, AstComment? internalComment)
+        public AstMessage(Identifier id, Pattern? pattern, List<Attribute> attrs, AstLocation location,
+            AstComment? internalComment)
         {
             Id = id;
             Value = pattern;
             Attributes = attrs;
+            Location = location;
             InternalComment = internalComment;
         }
 
@@ -67,15 +71,18 @@ namespace Linguini.Syntax.Ast
     {
         public readonly Identifier Id;
         public readonly Pattern Value;
+        public readonly AstLocation Location;
         public readonly List<Attribute> Attributes;
         public AstComment? Comment => InternalComment;
         protected internal AstComment? InternalComment;
 
-        public AstTerm(Identifier id, Pattern value, List<Attribute> attributes, AstComment? comment)
+        public AstTerm(Identifier id, Pattern value, List<Attribute> attributes, AstLocation location,
+            AstComment? comment)
         {
             Id = id;
             Value = value;
             Attributes = attributes;
+            Location = location;
             InternalComment = comment;
         }
 
@@ -84,6 +91,32 @@ namespace Linguini.Syntax.Ast
         {
             return Id.ToString();
         }
+    }
+
+    public class AstLocation
+    {
+        public static readonly AstLocation EMPTY = new(-1, "???");
+
+        public AstLocation(int row, string fileName)
+        {
+            Row = row;
+            FileName = fileName;
+        }
+
+        public AstLocation(ZeroCopyReader reader)
+        {
+            Row = reader.Row;
+            FileName = reader.FileName;
+        }
+
+        public AstLocation FromReader(ZeroCopyReader reader)
+        {
+            return new(reader.Row, reader.FileName ?? "???");
+        }
+
+        public string FileName { get; }
+
+        public int Row { get; }
     }
 
     public class AstComment : IEntry, IEquatable<AstComment>

--- a/Linguini.Syntax/Ast/Entry.cs
+++ b/Linguini.Syntax/Ast/Entry.cs
@@ -95,21 +95,20 @@ namespace Linguini.Syntax.Ast
 
     public class AstLocation
     {
-        public static readonly AstLocation EMPTY = new(-1, "???");
+        public static readonly AstLocation Empty = new(-1, "???");
 
-        public AstLocation(int row, string fileName)
+        private AstLocation(int row, string fileName)
         {
             Row = row;
             FileName = fileName;
         }
 
-        public AstLocation(ZeroCopyReader reader)
+        public static AstLocation FromRowAndFilename(int row, string fileName)
         {
-            Row = reader.Row;
-            FileName = reader.FileName;
+            return new AstLocation(row, fileName);
         }
 
-        public AstLocation FromReader(ZeroCopyReader reader)
+        public static AstLocation FromReader(ZeroCopyReader reader)
         {
             return new(reader.Row, reader.FileName ?? "???");
         }

--- a/Linguini.Syntax/Ast/Entry.cs
+++ b/Linguini.Syntax/Ast/Entry.cs
@@ -63,7 +63,7 @@ namespace Linguini.Syntax.Ast
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Id, Value, Attributes, InternalComment);
+            return HashCode.Combine(Id, Value, Attributes, Comment);
         }
     }
 

--- a/Linguini.Syntax/IO/ZeroCopyReader.cs
+++ b/Linguini.Syntax/IO/ZeroCopyReader.cs
@@ -11,16 +11,18 @@ namespace Linguini.Syntax.IO
         private readonly ReadOnlyMemory<char> _unconsumedData;
         private int _position;
         private int _row;
+        private string? _fileName;
 
-        public ZeroCopyReader(string text) : this(text.AsMemory())
+        public ZeroCopyReader(string text, string? fileName = null) : this(text.AsMemory(), fileName)
         {
         }
 
-        private ZeroCopyReader(ReadOnlyMemory<char> memory)
+        private ZeroCopyReader(ReadOnlyMemory<char> memory, string? fileName = null)
         {
             _unconsumedData = memory;
             _position = 0;
             _row = 1;
+            _fileName = fileName;
         }
 
         public int Position
@@ -33,6 +35,11 @@ namespace Linguini.Syntax.IO
         {
             get => _row;
             set => _row = value;
+        }
+
+        public string? FileName
+        {
+            get => _fileName;
         }
 
         public bool IsNotEof => _position < _unconsumedData.Length;

--- a/Linguini.Syntax/Parser/LinguiniParser.cs
+++ b/Linguini.Syntax/Parser/LinguiniParser.cs
@@ -21,7 +21,8 @@ namespace Linguini.Syntax.Parser
         private readonly bool _enableExperimental;
         private const string Cr = "\n";
 
-        private LinguiniParser(ZeroCopyReader zeroCopyReader, bool enableExperimental)
+        [Obsolete("Consider using LinguiniParser.FromFile factory method instead", true)]
+        public LinguiniParser(ZeroCopyReader zeroCopyReader, bool enableExperimental)
         {
             _reader = zeroCopyReader;
             _enableExperimental = enableExperimental;
@@ -32,12 +33,10 @@ namespace Linguini.Syntax.Parser
         /// </summary>
         /// <param name="input">Input to be parsed</param>
         /// <param name="enableExperimental">Using non-standard Fluent extensions</param>
-        /// <param name="filename">Name for input to be used in error reporting</param>
-        [Obsolete("Consider using LinguiniParser.FromFile factory method instead")]
-        public LinguiniParser(string input, bool enableExperimental = false, string filename = "")
+        [Obsolete("Consider using LinguiniParser.FromFragement factory method instead", true)]
+        public LinguiniParser(string input, bool enableExperimental = false) : this(new ZeroCopyReader(input),
+            enableExperimental)
         {
-            _reader = new ZeroCopyReader(input, filename);
-            _enableExperimental = enableExperimental;
         }
 
 
@@ -47,8 +46,19 @@ namespace Linguini.Syntax.Parser
         /// <param name="input">TextReader to be parsed to Fluent AST.</param>
         /// <param name="enableExperimental">Using non-standard Fluent extensions</param>
         /// <param name="filename">Name for input to be used in error reporting</param>
-        [Obsolete("Consider using LinguiniParser.FromTextReader factory method instead")]
-        public LinguiniParser(TextReader input, bool enableExperimental = false, string filename = "")
+        [Obsolete("Consider using LinguiniParser.FromTextReader factory method instead", true)]
+        public LinguiniParser(TextReader input, bool enableExperimental = false) : this(input.ReadToEnd(),
+            enableExperimental)
+        {
+        }
+
+        /// <summary>
+        /// Create new parser for <c>TextReader</c>
+        /// </summary>
+        /// <param name="input">TextReader to be parsed to Fluent AST.</param>
+        /// <param name="enableExperimental">Using non-standard Fluent extensions</param>
+        /// <param name="filename">Name for input to be used in error reporting</param>
+        private LinguiniParser(TextReader input, bool enableExperimental, string filename = "")
         {
             using (input)
             {
@@ -65,7 +75,7 @@ namespace Linguini.Syntax.Parser
         /// <param name="enableExperimental">Using non-standard Fluent extensions</param>
         public static LinguiniParser FromTextReader(TextReader input, string inputName, bool enableExperimental = false)
         {
-            return new LinguiniParser(new ZeroCopyReader(input.ReadToEnd(), inputName), enableExperimental);
+            return new LinguiniParser(input, enableExperimental, inputName);
         }
 
         /// <summary>
@@ -75,8 +85,8 @@ namespace Linguini.Syntax.Parser
         /// <param name="enableExperimental">Using non-standard Fluent extensions</param>
         public static LinguiniParser FromFile(string filename, bool enableExperimental = false)
         {
-            using StreamReader reader = File.OpenText(filename);
-            return new LinguiniParser(new ZeroCopyReader(reader.ReadToEnd(), filename), enableExperimental);
+            using var reader = File.OpenText(filename);
+            return new LinguiniParser(reader, enableExperimental, filename);
         }
 
         /// <summary>
@@ -88,7 +98,7 @@ namespace Linguini.Syntax.Parser
         public static LinguiniParser FromFragment(string input, string? fragmentName = null,
             bool enableExperimental = false)
         {
-            return new LinguiniParser(new ZeroCopyReader(input, fragmentName), enableExperimental);
+            return new LinguiniParser(new StringReader(input), enableExperimental, fragmentName);
         }
 
         public ReadOnlyMemory<char> GetReadonlyData => _reader.GetData;

--- a/Linguini.Syntax/Parser/LinguiniParser.cs
+++ b/Linguini.Syntax/Parser/LinguiniParser.cs
@@ -85,7 +85,7 @@ namespace Linguini.Syntax.Parser
         /// <param name="input">String to be parsed.</param>
         /// <param name="fragmentName">Optional fragment name of the string. Defaults to `????`.</param>
         /// <param name="enableExperimental">Using non-standard Fluent extensions</param>
-        public static LinguiniParser FromFragment(string input, string fragmentName = "????",
+        public static LinguiniParser FromFragment(string input, string? fragmentName = null,
             bool enableExperimental = false)
         {
             return new LinguiniParser(new ZeroCopyReader(input, fragmentName), enableExperimental);

--- a/Linguini.Syntax/Parser/LinguiniParser.cs
+++ b/Linguini.Syntax/Parser/LinguiniParser.cs
@@ -292,7 +292,7 @@ namespace Linguini.Syntax.Parser
 
             if (value != null)
             {
-                entry = new AstTerm(id, value, attribute, new AstLocation(_reader), null);
+                entry = new AstTerm(id, value, attribute, AstLocation.FromReader(_reader), null);
                 return (entry, error);
             }
             else
@@ -330,7 +330,7 @@ namespace Linguini.Syntax.Parser
                 return (entry, ParseError.ExpectedMessageField(id.Name, entryStart, _reader.Position, _reader.Row));
             }
 
-            return (new AstMessage(id, pattern, attrs, new AstLocation(_reader), null), null);
+            return (new AstMessage(id, pattern, attrs, AstLocation.FromReader(_reader), null), null);
         }
 
 


### PR DESCRIPTION
## What's changed
Adds tracking of `AstLocation` through parser.

### ZeroCopyReader
- Adds tracking for `AstLocation` which tracks where the bundle came from.

### Parser
- Obsoletes `LinguiniParser` constructor. Introduce `FromFile`, `FromFragment`, `FromTextReader` factory method that deal with `AstLocation`.
- Add `AstLocation` to all IEntry descendants.

### Bundle
- Propagate `AstLocation` throughout bundle.
- Obsoletes `AddResources(IEnumerable<string>)` and `AddResources(params string[])` from `IResourceStep`.

### Serialization
- Propagate changes in Serialization from adding `AstLocation`.

### SourceGenerator
- Moved generator to Lang version 12.
- Refactored CldrParser `class` -> `struct`.

Fixes #55 