### PR TITLE
Reintroduce `FormatPattern` method to `FluentBundle`, `FrozenBundle`, `ConcurrentBundle`

### DIFF
--- a/Linguini.Bundle.Test/Unit/BundleTests.cs
+++ b/Linguini.Bundle.Test/Unit/BundleTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Linguini.Bundle.Builder;
@@ -348,6 +349,24 @@ new1  = new
 
             Assert.That(original3.GetMessage("term"), Is.EqualTo("foo"));
             Assert.That(copy3.GetMessage("term"), Is.EqualTo("FOO"));
+        }
+
+        [Test]
+        [Parallelizable]
+        public void TestFormatPattern()
+        {
+            var reader = new StringReader("term = foo");
+            var builder = LinguiniBuilder.Builder()
+                .Locale("en-Us")
+                .AddResource(reader)
+                .UncheckedBuild();
+
+            var correct = builder.TryGetAstMessage("term", out var astMessage);
+            Assert.That(correct, Is.True);
+            Assert.That(astMessage, Is.Not.Null);
+            Assert.That(astMessage.Value, Is.Not.Null);
+            builder.FormatPattern(astMessage.Value, null, out var err);
+            Assert.That(err, Is.Null);
         }
     }
 }

--- a/Linguini.Bundle.Test/Yaml/YamlSuiteParser.cs
+++ b/Linguini.Bundle.Test/Yaml/YamlSuiteParser.cs
@@ -191,7 +191,8 @@ namespace Linguini.Bundle.Test.Yaml
             IList<FluentError>? errs,
             string testName)
         {
-            Assert.That(expectedErrors.Count, Is.EqualTo(errs!.Count), testName);
+            var errCount = errs?.Count ?? 0;
+            Assert.That(errCount, Is.EqualTo(expectedErrors.Count), testName);
             for (var i = 0; i < expectedErrors.Count; i++)
             {
                 var actualError = errs[i];

--- a/Linguini.Bundle/ConcurrentBundle.cs
+++ b/Linguini.Bundle/ConcurrentBundle.cs
@@ -18,7 +18,7 @@ namespace Linguini.Bundle
     ///
     /// `ConcurrentBundle` implements the <see cref="IReadBundle"/> interface.
     /// </summary>
-    public sealed class ConcurrentBundle : FluentBundle, IEquatable<ConcurrentBundle>
+    public sealed class ConcurrentBundle : FluentBundle, IEquatable<ConcurrentBundle>, IReadBundle
     {
         internal ConcurrentDictionary<string, FluentFunction> Functions = new();
         internal ConcurrentDictionary<string, AstTerm> Terms = new();

--- a/Linguini.Bundle/FluentBundle.cs
+++ b/Linguini.Bundle/FluentBundle.cs
@@ -132,8 +132,16 @@ namespace Linguini.Bundle
         {
             var scope = new Scope(this, args);
             var value = pattern.FormatPattern(scope);
-            errors = scope.Errors;
+            errors = scope.Errors.Count > 0 ? scope.Errors : null;
             return value;
+        }
+
+        /// <inheritdoc/>
+        /// Convenience method for calling <see cref="IReadBundle.FormatPattern"/>
+        public string FormatPattern(Pattern pattern, IDictionary<string, IFluentType>? args, [NotNullWhen(false)] out IList<FluentError>? errors)
+        {
+            errors = null;
+            return FormatPatternErrRef(pattern, args, ref errors);
         }
 
         /// <summary>

--- a/Linguini.Bundle/FrozenBundle.cs
+++ b/Linguini.Bundle/FrozenBundle.cs
@@ -120,6 +120,14 @@ namespace Linguini.Bundle
             errors = scope.Errors;
             return value;
         }
+        
+        /// <inheritdoc/>
+        /// Convenience method for calling <see cref="IReadBundle.FormatPattern"/>
+        public string FormatPattern(Pattern pattern, IDictionary<string, IFluentType>? args, [NotNullWhen(false)] out IList<FluentError>? errors)
+        {
+            errors = null;
+            return FormatPatternErrRef(pattern, args, ref errors);
+        }
 
         /// <inheritdoc/>
         public bool TryGetAstMessage(string ident, [NotNullWhen(true)] out AstMessage? message)

--- a/Linguini.Bundle/Linguini.Bundle.csproj
+++ b/Linguini.Bundle/Linguini.Bundle.csproj
@@ -18,7 +18,7 @@ It provides easy to use and extend system for describing translations.</Descript
         <Win32Resource />
         <PackageProjectUrl>https://github.com/Ygg01/Linguini</PackageProjectUrl>
         <RepositoryType>git</RepositoryType>
-        <PackageVersion>0.10.1</PackageVersion>
+        <PackageVersion>0.10.2</PackageVersion>
         <TargetFrameworks>net8.0;netstandard2.1;net6.0</TargetFrameworks>
         <PackageIcon>linguini.jpg</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/changelog.md
+++ b/changelog.md
@@ -292,3 +292,8 @@ version 0.10.2
 
 ### Syntax
 - Fixes issue with non-literals allowed as named term arguments.
+
+### Bundle
+- Reintroduce `FormatPattern` method from `IReadBundle` to `FluentBundle`, `FrozenBundle`.
+- Add `IReadBundle` interface to `ConcurrentBundle` (it implements it via `FluentBundle`).
+- Change so `FormatPatternErrRef` parameter `ref IList<FluentError>? errors` returns null if no errors found.


### PR DESCRIPTION
- Reintroduces `FormatPattern` to various `FluentBundle`.

- Adds `IReadBundle` to `ConcurrentBundle`.

- Changes `FormatPatternErrRef` to return null if no errors.

